### PR TITLE
feat(common, app): API 응답 및 공통 에러 형식 정의

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,10 @@
+val springMockkVersion: String by project
+
 dependencies {
     implementation(project(":common"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.ninja-squad:springmockk:$springMockkVersion")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,1 +1,7 @@
-dependencies {}
+dependencies {
+    implementation(project(":common"))
+
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}

--- a/app/src/main/kotlin/com/fastcampus/commerce/app/error/GlobalExceptionHandler.kt
+++ b/app/src/main/kotlin/com/fastcampus/commerce/app/error/GlobalExceptionHandler.kt
@@ -1,0 +1,32 @@
+package com.fastcampus.commerce.app.error
+
+import com.fastcampus.commerce.common.error.CommonErrorCode
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.common.error.ErrorMessage
+import com.fastcampus.commerce.common.logging.LogLevel
+import com.fastcampus.commerce.common.response.ApiResponse
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler(
+    private val log: Logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java),
+) {
+    @ExceptionHandler(CoreException::class)
+    fun handleCoreException(e: CoreException): ApiResponse<Nothing?> {
+        when (e.errorCode.logLevel) {
+            LogLevel.ERROR -> log.error("CoreException: {}", e.message, e)
+            LogLevel.WARN -> log.warn("CoreException: {}", e.message, e)
+            LogLevel.INFO -> log.info("CoreException: {}", e.message, e)
+        }
+        return ApiResponse.error(ErrorMessage(e.errorCode))
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception): ApiResponse<Nothing?> {
+        log.error("Exception: {}", e.message, e)
+        return ApiResponse.error(ErrorMessage(CommonErrorCode.SERVER_ERROR))
+    }
+}

--- a/app/src/main/kotlin/com/fastcampus/commerce/app/response/ApiResponseAdvice.kt
+++ b/app/src/main/kotlin/com/fastcampus/commerce/app/response/ApiResponseAdvice.kt
@@ -1,0 +1,44 @@
+package com.fastcampus.commerce.app.response
+
+import com.fastcampus.commerce.common.response.ApiResponse
+import org.springframework.core.MethodParameter
+import org.springframework.core.env.Environment
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+@ControllerAdvice
+class ApiResponseAdvice(
+    private val environment: Environment,
+) : ResponseBodyAdvice<Any> {
+    override fun supports(returnType: MethodParameter, converterType: Class<out HttpMessageConverter<*>?>): Boolean = true
+
+    override fun beforeBodyWrite(
+        body: Any?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>?>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+    ): Any? {
+        if (body is String) {
+            val activeProfiles = environment.activeProfiles
+            val isDevelopmentProfile = activeProfiles.any {
+                it.equals("dev", ignoreCase = true) ||
+                    it.equals("test", ignoreCase = true) ||
+                    it.equals("local", ignoreCase = true)
+            }
+            if (isDevelopmentProfile) {
+                throw IllegalStateException("String 리턴 금지")
+            }
+        }
+
+        if (body is ApiResponse<*>) {
+            return body
+        }
+        return ApiResponse.success(body)
+    }
+}

--- a/app/src/test/kotlin/com/fastcampus/commerce/app/error/GlobalExceptionHandlerTest.kt
+++ b/app/src/test/kotlin/com/fastcampus/commerce/app/error/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,111 @@
+package com.fastcampus.commerce.app.error
+
+import com.fastcampus.commerce.common.error.CommonErrorCode
+import com.fastcampus.commerce.common.error.CoreException
+import com.fastcampus.commerce.common.error.ErrorCode
+import com.fastcampus.commerce.common.error.ErrorMessage
+import com.fastcampus.commerce.common.logging.LogLevel
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.mockk
+import io.mockk.verify
+import org.slf4j.Logger
+
+class GlobalExceptionHandlerTest : FunSpec(
+    {
+        val mockLogger = mockk<Logger>(relaxed = true)
+        val handler = GlobalExceptionHandler(log = mockLogger)
+
+        beforeEach {
+            clearMocks(mockLogger)
+        }
+
+        context("CoreException 처리 시") {
+            test("ApiResponse.error 객체를 반환한다.") {
+                val expectedCode = CommonErrorCode.SERVER_ERROR
+                val expectedError = ErrorMessage(expectedCode)
+                val exception = CoreException(expectedCode)
+
+                val sut = handler.handleCoreException(exception)
+
+                sut.data shouldBe null
+                sut.error shouldBe expectedError
+                sut.error?.code shouldBe expectedError.code
+                sut.error?.message shouldBe expectedError.message
+            }
+
+            test("ERROR 레벨 로깅이 되어야 한다.") {
+                val errorCode = object : ErrorCode {
+                    override val code: String = "TST-001"
+                    override val message: String = "테스트 에러"
+                    override val logLevel: LogLevel = LogLevel.ERROR
+                }
+                val exception = CoreException(errorCode)
+
+                handler.handleCoreException(exception)
+
+                verify { mockLogger.error("CoreException: {}", exception.message, exception) }
+            }
+
+            test("WARN 레벨 로깅이 되어야 한다.") {
+                val errorCode = object : ErrorCode {
+                    override val code: String = "TST-001"
+                    override val message: String = "테스트 에러"
+                    override val logLevel: LogLevel = LogLevel.WARN
+                }
+                val exception = CoreException(errorCode)
+
+                handler.handleCoreException(exception)
+
+                verify { mockLogger.warn("CoreException: {}", exception.message, exception) }
+            }
+
+            test("INFO 레벨 로깅이 되어야 한다.") {
+                val errorCode = object : ErrorCode {
+                    override val code: String = "TST-001"
+                    override val message: String = "테스트 에러"
+                    override val logLevel: LogLevel = LogLevel.INFO
+                }
+                val exception = CoreException(errorCode)
+
+                handler.handleCoreException(exception)
+
+                verify { mockLogger.info("CoreException: {}", exception.message, exception) }
+            }
+        }
+
+        context("CoreException을 제외한 Exception 처리 시") {
+            test("기본 에러 응답과 ERROR 로깅이 되어야 한다.") {
+                val expectedError = ErrorMessage(CommonErrorCode.SERVER_ERROR)
+                val expectedLoggingMessage = "알 수 없는 오류"
+                val exception = RuntimeException(expectedLoggingMessage)
+
+                val sut = handler.handleException(exception)
+
+                sut.data shouldBe null
+                sut.error shouldBe expectedError
+                sut.error?.code shouldBe expectedError.code
+                sut.error?.message shouldBe expectedError.message
+
+                verify { mockLogger.error("Exception: {}", exception.message, exception) }
+            }
+        }
+
+        context("로그 호출 횟수 검증") {
+            test("예외가 발생한 만큼 로그가 호출되어야 한다.") {
+                repeat(3) {
+                    handler.handleException(RuntimeException("Error $it"))
+                }
+
+                verify(exactly = 3) {
+                    mockLogger.error(
+                        "Exception: {}",
+                        match { message: String -> message.startsWith("Error ") },
+                        ofType<RuntimeException>(),
+                    )
+                }
+            }
+        }
+    },
+)

--- a/app/src/test/kotlin/com/fastcampus/commerce/app/response/ApiResponseAdviceTest.kt
+++ b/app/src/test/kotlin/com/fastcampus/commerce/app/response/ApiResponseAdviceTest.kt
@@ -1,0 +1,73 @@
+package com.fastcampus.commerce.app.response
+
+import com.fastcampus.commerce.common.response.ApiResponse
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import jakarta.servlet.ServletException
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class ApiResponseAdviceTest(
+    @Autowired private val mockMvc: MockMvc,
+) : DescribeSpec(
+        {
+            describe("ApiResponseAdvice") {
+                it("String을 반환하면 IllegalStateException를 반환한다.") {
+                    val thrown = shouldThrow<ServletException> {
+                        mockMvc.get("/test/string")
+                    }
+
+                    thrown.rootCause is IllegalStateException
+                    thrown.rootCause.message shouldBe "String 리턴 금지"
+                }
+
+                it("객체를 반환하면 ApiResponse로 감싸진다") {
+                    mockMvc.get("/test/object")
+                        .andExpect {
+                            status { isOk() }
+                            jsonPath("$.data.foo") { value("bar") }
+                            jsonPath("$.error") { doesNotExist() }
+                        }
+                }
+
+                it("ApiResponse 객체를 반환하면 그대로 응답된다") {
+                    mockMvc.get("/test/api-response")
+                        .andExpect {
+                            status { isOk() }
+                            jsonPath("$.data.foo") { value("bar") }
+                            jsonPath("$.error") { doesNotExist() }
+                        }
+                }
+            }
+        },
+    )
+
+@RestController
+@RequestMapping("/test")
+class ApiResponseAdviceTestController {
+    @GetMapping("/string")
+    fun getString(): String {
+        return "hello world"
+    }
+
+    @GetMapping("/object")
+    fun getObject(): Map<String, Any> {
+        return mapOf("foo" to "bar")
+    }
+
+    @GetMapping("/api-response")
+    fun getApiResponse(): ApiResponse<Map<String, Any>> {
+        return ApiResponse.success(data = mapOf("foo" to "bar"))
+    }
+}

--- a/common/src/main/kotlin/com/fastcampus/commerce/common/error/CommonErrorCode.kt
+++ b/common/src/main/kotlin/com/fastcampus/commerce/common/error/CommonErrorCode.kt
@@ -1,0 +1,11 @@
+package com.fastcampus.commerce.common.error
+
+import com.fastcampus.commerce.common.logging.LogLevel
+
+enum class CommonErrorCode(
+    override val code: String,
+    override val message: String,
+    override val logLevel: LogLevel,
+) : ErrorCode {
+    SERVER_ERROR("SYS-001", "An unexpected error has occurred.", LogLevel.ERROR),
+}

--- a/common/src/main/kotlin/com/fastcampus/commerce/common/error/CoreException.kt
+++ b/common/src/main/kotlin/com/fastcampus/commerce/common/error/CoreException.kt
@@ -1,0 +1,5 @@
+package com.fastcampus.commerce.common.error
+
+class CoreException(
+    val errorCode: ErrorCode,
+) : RuntimeException(errorCode.message)

--- a/common/src/main/kotlin/com/fastcampus/commerce/common/error/ErrorCode.kt
+++ b/common/src/main/kotlin/com/fastcampus/commerce/common/error/ErrorCode.kt
@@ -1,0 +1,9 @@
+package com.fastcampus.commerce.common.error
+
+import com.fastcampus.commerce.common.logging.LogLevel
+
+interface ErrorCode {
+    val code: String
+    val message: String
+    val logLevel: LogLevel
+}

--- a/common/src/main/kotlin/com/fastcampus/commerce/common/error/ErrorMessage.kt
+++ b/common/src/main/kotlin/com/fastcampus/commerce/common/error/ErrorMessage.kt
@@ -2,10 +2,10 @@ package com.fastcampus.commerce.common.error
 
 data class ErrorMessage private constructor(
     val code: String,
-    val message: String
+    val message: String,
 ) {
     constructor(errorCode: ErrorCode) : this(
         code = errorCode.code,
-        message = errorCode.message
+        message = errorCode.message,
     )
 }

--- a/common/src/main/kotlin/com/fastcampus/commerce/common/error/ErrorMessage.kt
+++ b/common/src/main/kotlin/com/fastcampus/commerce/common/error/ErrorMessage.kt
@@ -1,0 +1,11 @@
+package com.fastcampus.commerce.common.error
+
+data class ErrorMessage private constructor(
+    val code: String,
+    val message: String
+) {
+    constructor(errorCode: ErrorCode) : this(
+        code = errorCode.code,
+        message = errorCode.message
+    )
+}

--- a/common/src/main/kotlin/com/fastcampus/commerce/common/logging/LogLevel.kt
+++ b/common/src/main/kotlin/com/fastcampus/commerce/common/logging/LogLevel.kt
@@ -1,5 +1,7 @@
 package com.fastcampus.commerce.common.logging
 
 enum class LogLevel {
-    INFO, WARN, ERROR
+    INFO,
+    WARN,
+    ERROR,
 }

--- a/common/src/main/kotlin/com/fastcampus/commerce/common/logging/LogLevel.kt
+++ b/common/src/main/kotlin/com/fastcampus/commerce/common/logging/LogLevel.kt
@@ -1,0 +1,5 @@
+package com.fastcampus.commerce.common.logging
+
+enum class LogLevel {
+    INFO, WARN, ERROR
+}

--- a/common/src/main/kotlin/com/fastcampus/commerce/common/response/ApiResponse.kt
+++ b/common/src/main/kotlin/com/fastcampus/commerce/common/response/ApiResponse.kt
@@ -1,0 +1,18 @@
+package com.fastcampus.commerce.common.response
+
+import com.fastcampus.commerce.common.error.ErrorMessage
+
+data class ApiResponse<T> private constructor(
+    val data: T? = null,
+    val error: ErrorMessage? = null
+) {
+    companion object {
+        fun <S> success(data: S): ApiResponse<S> {
+            return ApiResponse(data, null)
+        }
+
+        fun error(errorMessage: ErrorMessage): ApiResponse<Nothing?> {
+            return ApiResponse(null, errorMessage)
+        }
+    }
+}

--- a/common/src/main/kotlin/com/fastcampus/commerce/common/response/ApiResponse.kt
+++ b/common/src/main/kotlin/com/fastcampus/commerce/common/response/ApiResponse.kt
@@ -4,7 +4,7 @@ import com.fastcampus.commerce.common.error.ErrorMessage
 
 data class ApiResponse<T> private constructor(
     val data: T? = null,
-    val error: ErrorMessage? = null
+    val error: ErrorMessage? = null,
 ) {
     companion object {
         fun <S> success(data: S): ApiResponse<S> {

--- a/common/src/test/kotlin/com/fastcampus/commerce/common/error/ErrorMessageTest.kt
+++ b/common/src/test/kotlin/com/fastcampus/commerce/common/error/ErrorMessageTest.kt
@@ -1,0 +1,19 @@
+package com.fastcampus.commerce.common.error
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ErrorMessageTest : FunSpec(
+    {
+        test("ErrorMessage 객체를 생성할 수 있다.") {
+            val errorCode = CommonErrorCode.SERVER_ERROR
+            val expectedCode = errorCode.code
+            val expectedMessage = errorCode.message
+
+            val sut = ErrorMessage(errorCode)
+
+            sut.code shouldBe expectedCode
+            sut.message shouldBe expectedMessage
+        }
+    },
+)

--- a/common/src/test/kotlin/com/fastcampus/commerce/common/response/ApiResponseTest.kt
+++ b/common/src/test/kotlin/com/fastcampus/commerce/common/response/ApiResponseTest.kt
@@ -1,0 +1,25 @@
+package com.fastcampus.commerce.common.response
+
+import com.fastcampus.commerce.common.error.CommonErrorCode
+import com.fastcampus.commerce.common.error.ErrorMessage
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ApiResponseTest : FunSpec(
+    {
+        test("성공 응답을 생성할 수 있다.") {
+            val expectedData = "데이터"
+
+            val sut = ApiResponse.success(expectedData)
+
+            sut.data shouldBe expectedData
+        }
+        test("실패 응답을 생성할 수 있다.") {
+            val expectedError = ErrorMessage(CommonErrorCode.SERVER_ERROR)
+
+            val sut = ApiResponse.error(expectedError)
+
+            sut.error shouldBe expectedError
+        }
+    },
+)


### PR DESCRIPTION
## 🚩 PR 목적 (Why)

- 공통 응답을 위한 DTO 정의

---

## 🔍 주요 변경사항 (What)
<!-- 핵심 변경점 3~5줄 요약. 너무 길게 쓰지 말 것
- e.g.
- `/api/login` 엔드포인트 추가 (POST)
- JWT 발급 로직 `JwtTokenProvider` 생성
- 로그인 실패 시 에러 포맷 통일-->
- 공통 응답 DTO 정의 `ApiResponse`
- 최상위 예외 정의 `CoreException`
- 공통 에러 형식 정의
- 일반적인 객체 응답시 `ApiResponse`로 감싸는 기능 추가 `ApiResponseAdvice`
- 공통 예외 처리기 추가 `GlobalExceptionHandler`

---

## ⚙️ 구현 상세 (How)

- `ApiResponseAdvice`에서 String인 경우 Content-Type을 강제로 변경해줘야하는 이슈가 있음
- 실제로 String을 반환하는 경우가 많이 없으므로 이 경우 예외를 발생시키도록 처리
- 공통 예외 처리시 `ErrorCode`에 따라 로깅 레벨을 다르게 처리

---

## ✅ 테스트 내역

- [x] 단위 테스트: `ApiResonseTest`
- [x] 단위 테스트: `ErrorMessage` 
- [x] 단위 테스트: `ApiResponseAdviceTest`

---

## 🔗 관련 이슈

closes #5 
