### PR TITLE
Feature/auth naver authorization endpoint

### DIFF
--- a/modules/auth/build.gradle.kts
+++ b/modules/auth/build.gradle.kts
@@ -2,6 +2,11 @@ val jjwtVersion = "0.11.5"
 
 dependencies {
 
+    // WebClient
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+
     // Spring Security Core
     implementation("org.springframework.boot:spring-boot-starter-security")
 

--- a/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/config/SecurityConfig.kt
+++ b/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/config/SecurityConfig.kt
@@ -1,11 +1,18 @@
 package com.fastcampus.commerce.auth.config
 
+import com.fastcampus.commerce.auth.infrastructure.security.oauth.config.NaverOAuth2Properties
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
@@ -20,8 +27,12 @@ class CorsProperties {
 
 @Configuration
 @EnableWebSecurity
+@EnableConfigurationProperties(NaverOAuth2Properties::class)
 class SecurityConfig(
-    private val corsProperties: CorsProperties
+    private val corsProperties: CorsProperties,
+    private val customOAuth2UserService: OAuth2UserService<OAuth2UserRequest, OAuth2User>,
+    private val customSuccessHandler: AuthenticationSuccessHandler,
+    private val customFailureHandler: AuthenticationFailureHandler
 ) {
 
     @Bean
@@ -46,6 +57,21 @@ class SecurityConfig(
             .authorizeHttpRequests {
                 it.requestMatchers("/auth/login", "/auth/signup", "/oauth2/**").permitAll()
                     .anyRequest().authenticated()
+            }
+            .oauth2Login { oauth2 ->
+                oauth2
+                    .loginPage("/auth/login") // 커스텀 로그인 페이지가 있다면 설정
+                    .authorizationEndpoint { auth ->
+                        auth.baseUri("/oauth2/authorization") // ex) /oauth2/authorization/naver
+                    }
+                    .redirectionEndpoint { redir ->
+                        redir.baseUri("/login/oauth2/code/*") // redirect-uri 와 일치
+                    }
+                    .userInfoEndpoint { userInfo ->
+                        userInfo.userService(customOAuth2UserService) // OAuth2UserService 구현체 주입 필요
+                    }
+                    .successHandler(customSuccessHandler) // 선택
+                    .failureHandler(customFailureHandler) // 선택
             }
         return http.build()
     }

--- a/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/config/WebClientConfig.kt
+++ b/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/config/WebClientConfig.kt
@@ -1,0 +1,15 @@
+package com.fastcampus.commerce.auth.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfig {
+    @Bean
+    fun userWebClient(): WebClient {
+        return WebClient.builder()
+            .baseUrl("https://api.801base.com/userModule") // TODO: User Module 임시 설정, 추후 변경 필요
+            .build()
+    }
+}

--- a/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/infrastructure/client/UserClient.kt
+++ b/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/infrastructure/client/UserClient.kt
@@ -1,0 +1,34 @@
+package com.fastcampus.commerce.auth.infrastructure.client
+
+import com.fastcampus.commerce.auth.interfaces.web.security.oauth.NaverUserResponse
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+data class UserDto(
+    val id: Long,
+    val email: String?,
+    val nickname: String,
+    val roles: List<String>
+)
+
+@Component
+class UserApiClient(
+    @Qualifier("userWebClient") private val webClient: WebClient
+) {
+    private val log = LoggerFactory.getLogger(UserApiClient::class.java)
+    fun saveOrUpdateUser(oauthInfo: NaverUserResponse): UserDto {
+        try {
+            return webClient.post()
+                .uri("/api/users/oauth2")
+                .bodyValue(oauthInfo)
+                .retrieve()
+                .bodyToMono(UserDto::class.java)
+                .block() ?: throw IllegalStateException("User API 응답이 null입니다.")
+        } catch (ex: Exception) {
+            log.error("User API 호출 실패: ${ex.message}", ex)
+            throw IllegalStateException("User API 호출 중 에러", ex)
+        }
+    }
+}

--- a/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/infrastructure/security/oauth/config/NaverOAuth2Properties.kt
+++ b/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/infrastructure/security/oauth/config/NaverOAuth2Properties.kt
@@ -1,0 +1,32 @@
+package com.fastcampus.commerce.auth.infrastructure.security.oauth.config
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.properties.ConfigurationProperties
+import jakarta.annotation.PostConstruct
+
+private val log = LoggerFactory.getLogger(NaverOAuth2Properties::class.java)
+
+@ConfigurationProperties(prefix = "auth.oauth2.naver")
+data class NaverOAuth2Properties(
+    val clientId: String,
+    val clientSecret: String,
+    val redirectUri: String,
+    val scope: List<String>,
+    val authorizationGrantType: String,
+) {
+    @PostConstruct
+    fun logProps() {
+        println("Naver OAuth2 Config:")
+        println("- clientId: $clientId")
+        println("- clientSecret: $clientSecret")
+        println("- redirectUri: $redirectUri")
+        println("- authorizationGrantType: $authorizationGrantType")
+        println("- scope: $scope")
+        log.info("Naver OAuth2 NaverOAuth2Properties")
+        log.info("- clientId: $clientId")
+        log.info("- clientSecret: $clientSecret")
+        log.info("- redirectUri: $redirectUri")
+        log.info("- authorizationGrantType: $authorizationGrantType")
+        log.info("- scope: $scope")
+    }
+}

--- a/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/infrastructure/security/oauth/config/OAuth2ClientRegistrationConfig.kt
+++ b/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/infrastructure/security/oauth/config/OAuth2ClientRegistrationConfig.kt
@@ -1,0 +1,32 @@
+package com.fastcampus.commerce.auth.infrastructure.security.oauth.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.client.registration.ClientRegistration
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository
+import org.springframework.security.oauth2.core.AuthorizationGrantType
+
+@Configuration
+class OAuth2ClientRegistrationConfig(
+    private val naverProps: NaverOAuth2Properties
+) {
+
+    @Bean
+    fun clientRegistrationRepository(): ClientRegistrationRepository {
+        val naver = ClientRegistration.withRegistrationId("naver")
+            .clientId(naverProps.clientId)
+            .clientSecret(naverProps.clientSecret)
+            .redirectUri(naverProps.redirectUri)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .scope(*naverProps.scope.toTypedArray())
+            .authorizationUri("https://nid.naver.com/oauth2.0/authorize")
+            .tokenUri("https://nid.naver.com/oauth2.0/token")
+            .userInfoUri("https://openapi.naver.com/v1/nid/me")
+            .userNameAttributeName("id")
+            .clientName("Naver")
+            .build()
+
+        return InMemoryClientRegistrationRepository(naver)
+    }
+}

--- a/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/oauth/CustomOAuth2FailureHandler.kt
+++ b/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/oauth/CustomOAuth2FailureHandler.kt
@@ -1,0 +1,26 @@
+package com.fastcampus.commerce.auth.interfaces.web.security.oauth
+
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
+import org.springframework.stereotype.Component
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+private val log = LoggerFactory.getLogger(CustomOAuth2FailureHandler::class.java)
+
+@Component
+class CustomOAuth2FailureHandler : AuthenticationFailureHandler {
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        exception: AuthenticationException?,
+    ) {
+        // 1. 실패 로그 기록 (원인 파악에 필수)
+        println("OAuth2 로그인 실패: ${exception?.message}")
+        log.info("OAuth2 로그인 실패 원인: ${exception?.cause}")
+
+        // 2. 실패 시 로그인 페이지로 리다이렉트 + 에러 파라미터 전달
+        response?.sendRedirect("/auth/login?error=" + (exception?.message ?: "oauth2_failure"))
+    }
+}

--- a/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/oauth/CustomOAuth2SuccessHandler.kt
+++ b/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/oauth/CustomOAuth2SuccessHandler.kt
@@ -1,0 +1,31 @@
+package com.fastcampus.commerce.auth.interfaces.web.security.oauth
+
+import org.slf4j.LoggerFactory
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+
+private val log = LoggerFactory.getLogger(CustomOAuth2SuccessHandler::class.java)
+
+@Component
+class CustomOAuth2SuccessHandler : AuthenticationSuccessHandler {
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        authentication: Authentication?,
+    ) {
+        // 예시: JWT 발급 후 쿠키/헤더에 세팅
+        if (authentication == null || response == null) return
+        val user = authentication.principal as? CustomUserPrincipal ?: return
+        val token = "여기서 JWT 발급" //TODO: 여기서 user 객체 사용
+
+        response.addHeader("Authorization", "Bearer $token")
+        // 또는 리다이렉트
+        response.sendRedirect("/")
+
+        log.info("Successfully authenticated: $response")
+    }
+
+}

--- a/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/oauth/CustomOAuth2UserService.kt
+++ b/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/oauth/CustomOAuth2UserService.kt
@@ -1,0 +1,42 @@
+package com.fastcampus.commerce.auth.interfaces.web.security.oauth
+
+import com.fastcampus.commerce.auth.infrastructure.client.UserApiClient
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Service
+
+data class NaverUserResponse(
+    val id: String,
+    val email: String?,
+    val nickname: String?,
+    val profileImage: String?
+)
+
+@Service
+class CustomOAuth2UserService(
+    private val userApiClient: UserApiClient,
+) : OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private val delegate = DefaultOAuth2UserService()
+
+    override fun loadUser(userRequest: OAuth2UserRequest): OAuth2User {
+        val oAuth2User = delegate.loadUser(userRequest)
+        val responseMap = oAuth2User.attributes["response"] as? Map<*, *>
+            ?: throw IllegalStateException("Missing Naver response")
+
+        val naverUser = NaverUserResponse(
+            id = responseMap["id"]?.toString() ?: "",
+            email = responseMap["email"]?.toString(),
+            nickname = responseMap["nickname"]?.toString(),
+            profileImage = responseMap["profile_image"]?.toString()
+        )
+
+        // User 모듈에 API to API 호출
+        val userDto = userApiClient.saveOrUpdateUser(naverUser)
+
+        // 이후 Security에 등록할 Principal 반환
+        return CustomUserPrincipal.of(userDto)
+    }
+}

--- a/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/oauth/CustomUserPrincipal.kt
+++ b/modules/auth/src/main/kotlin/com/fastcampus/commerce/auth/interfaces/web/security/oauth/CustomUserPrincipal.kt
@@ -1,0 +1,25 @@
+package com.fastcampus.commerce.auth.interfaces.web.security.oauth
+
+import com.fastcampus.commerce.auth.infrastructure.client.UserDto
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+class CustomUserPrincipal(
+    private val user: UserDto
+) : OAuth2User {
+
+    override fun getName(): String = user.id.toString()
+    override fun getAttributes(): Map<String, Any> = mapOf(
+        "id" to user.id,
+        "email" to (user.email ?: ""),
+        "nickname" to (user.nickname ?: "")
+    )
+
+    override fun getAuthorities(): Collection<GrantedAuthority> =
+        user.roles.map { SimpleGrantedAuthority(it) }
+
+    companion object {
+        fun of(user: UserDto): CustomUserPrincipal = CustomUserPrincipal(user)
+    }
+}

--- a/modules/auth/src/main/resources/auth.yml
+++ b/modules/auth/src/main/resources/auth.yml
@@ -13,6 +13,7 @@ auth:
       client-id: OFAjwhciHWlXDEPTzYGW
       client-secret: 1MF0BuXZ31
       redirect-uri: http://localhost:8080/login/oauth2/code/naver
+      authorization-grant-type: authorization_code
       scope:
         - name
         - email


### PR DESCRIPTION
## 🚩 PR 목적 (Why)
- 네이버 소셜 로그인 연동을 위한 OAuth2 인증 플로우 1차 구현

---

## 🔍 주요 변경사항 (What)
- 네이버 OAuth2 Properties 설정 추가
- Custom OAuth2UserService, UserPrincipal, Success/Failure Handler 구현
- User API 연동 WebClient 추가
- SecurityConfig에 OAuth2 및 CORS 설정 반영

---

## ⚙️ 구현 상세 (How)
- 인증 성공/실패시 처리 로직 핸들러 구분 (JWT 발급은 추후 연동)
- User 정보는 User API를 통해 가져오는 구조 설계
- Exception 발생 시 로깅 및 기본 에러 처리
- OAuth2 기본 flow 검증 (로컬 환경 기준)

---

## ✅ 테스트 내역
- [x] 수동 테스트: 네이버 로그인 플로우 직접 수행 및 정상 리다이렉트 확인

---

## 🔗 관련 이슈
<!-- e.g. closes #33 -->

---

## 👀 리뷰 포인트
- OAuth2 인증 성공/실패 핸들러 구조가 명확한지
- 네이버 소셜 로그인 창이 정상적으로 보이는지